### PR TITLE
Let object_lookup return objects directly, not brains.

### DIFF
--- a/ftw/mopage/browser/base.py
+++ b/ftw/mopage/browser/base.py
@@ -91,11 +91,10 @@ class BaseExport(BrowserView):
         lookup_provider = getMultiAdapter(
             (self.context, self.request), self.lookup_provider)
 
-        brains = lookup_provider.get_brains()
+        objects = lookup_provider.get_objects()
 
         xml_data = []
-        for brain in brains:
-            obj = brain.getObject()
+        for obj in objects:
 
             data_provider = getMultiAdapter(
                 (obj, self.request), self.data_provider)

--- a/ftw/mopage/interfaces.py
+++ b/ftw/mopage/interfaces.py
@@ -107,9 +107,9 @@ class IMopageObjectLookup(Interface):
     Adapter to lookup objects providing data for the xml export
     """
 
-    def get_brains():
+    def get_objects():
         """
-        Return brains providing data for the xml export
+        Return objects providing data for the xml export
         """
 
 

--- a/ftw/mopage/object_lookup.py
+++ b/ftw/mopage/object_lookup.py
@@ -12,10 +12,13 @@ class MopageBaseObjectLookup(object):
         self.context = context
         self.request = request
 
-    def get_brains(self):
+    def _get_brains(self):
         catalog = getToolByName(self.context, 'portal_catalog')
 
         return catalog({'object_provides': self.interface})
+
+    def get_objects(self):
+        return [each.getObject() for each in self._get_brains()]
 
 
 class MopageEventObjectLookup(MopageBaseObjectLookup):


### PR DESCRIPTION
This PR proposes to change the interface of `IMopageObjectLookup` and return objects directly. 

This makes it easier to implement additional filters in `IMopageObjectLookup` that cannot be done with a catalog query or the brains but need the actual objects.
